### PR TITLE
Set the primary bucket in the json

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -29,7 +29,7 @@ const FieldValue = admin.firestore.FieldValue;
 
 // App-specific default bucket for storage. Used to upload takeout json and in
 // sample json of wipeout and takeout paths.
-const appBucketName = 'wipeout-takeout.appspot.com';
+const appBucketName = userPrivacyPaths.primaryBucketName;
 
 // Wipeout
 //

--- a/functions/index.js
+++ b/functions/index.js
@@ -29,7 +29,7 @@ const FieldValue = admin.firestore.FieldValue;
 
 // App-specific default bucket for storage. Used to upload takeout json and in
 // sample json of wipeout and takeout paths.
-const appBucketName = userPrivacyPaths.primaryBucketName;
+const appBucketName = userPrivacyPaths.takeoutUploadBucket;
 
 // Wipeout
 //

--- a/functions/index.js
+++ b/functions/index.js
@@ -29,7 +29,7 @@ const FieldValue = admin.firestore.FieldValue;
 
 // App-specific default bucket for storage. Used to upload takeout json and in
 // sample json of wipeout and takeout paths.
-const appBucketName = userPrivacyPaths.takeoutUploadBucket;
+const takeoutBucket = userPrivacyPaths.takeoutUploadBucket;
 
 // Wipeout
 //
@@ -256,7 +256,7 @@ const storageTakeout = (uid) => {
     );
     // Add the copy task to the array of Promises
     promises.push(copyPromise);
-    takeout[`${entryBucket}/${path}`] = `${appBucketName}/${destinationPath}`;
+    takeout[`${entryBucket}/${path}`] = `${takeoutBucket}/${destinationPath}`;
   }
   return Promise.all(promises).then(() => takeout);
 };
@@ -269,7 +269,7 @@ const storageTakeout = (uid) => {
 // Called by the top-level takeout function.
 const uploadToStorage = (uid, takeout) => {
   const json = JSON.stringify(takeout);
-  const bucket = storage.bucket(appBucketName);
+  const bucket = storage.bucket(takeoutBucket);
   const file = bucket.file(`takeout/${uid}/takeout.json`);
 
   return file.save(json);

--- a/functions/user_privacy.json
+++ b/functions/user_privacy.json
@@ -1,4 +1,5 @@
 {
+  "primaryBucketName": "wipeout-takeout.appspot.com",
   "database": {
     "wipeout": [
       "/users/UID_VARIABLE",

--- a/functions/user_privacy.json
+++ b/functions/user_privacy.json
@@ -1,5 +1,5 @@
 {
-  "primaryBucketName": "wipeout-takeout.appspot.com",
+  "takeoutUploadBucket": "wipeout-takeout.appspot.com",
   "database": {
     "wipeout": [
       "/users/UID_VARIABLE",


### PR DESCRIPTION
By moving the place the developer sets the default storage bucket from `functions/index.js` to `functions/user_privacy.json`, the developer can do all the customization in `user_privacy.json`, which will make it a bit nicer to include this.