### PR TITLE
Steps to use these functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,6 @@ and copying out data at when a user requests it (the [`takeout` function]()).
 The functions are  flexible and easy to change to fit the needs of your specific
 users and apps.
 
-### How to contribute
-
-- [ ] Clone this repository
-- [ ] Create a new firebase project and go through the `firebase init` flow.
-This project uses Hosting, Functions, the RealTime Database, Firestore, and
-Storage.
-- [ ] `cd` into the `functions` directory and `npm install`
-- [ ] Run `firebase deploy`
-
 
 ### How to use these functions in your own project
 
@@ -97,3 +88,14 @@ for the takeout folder to the Storage Rules.
 - [ ] Look through any preexisting Storage Rules; if a rule grants broader
 access to the takeout data, update that rule. Remember that if one rule grants
 access, another cannot restrict it.
+
+### How to contribute to this repo
+
+- [ ] Clone this repository
+- [ ] Create a new firebase project and go through the `firebase init` flow.
+This project uses Hosting, Functions, the RealTime Database, Firestore, and
+Storage.
+- [ ] `cd` into the `functions` directory and `npm install`
+- [ ] Run `firebase deploy`
+- [ ] Make the changes you're interested in
+- [ ] Submit a Pull Request explaining the problem and solution.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ name of the form:
 The wipeout function as written is triggered when a user deletes their account
 using Firebase Auth, and it performs a wipeout from all three services.
 
-Steps to start using wipeout:
+**Steps to start using wipeout:**
+
 - [ ] Include the wipeout function and 3 supporting functions (and the requires
   and convenience variables) in `functions/index.js`
 - [ ] In `user_privacy.json`, add paths to personal information for all the
@@ -57,7 +58,7 @@ The takeout function is triggered via a HTTP request. The sample app in
 `/public` has a button that’s wired up to trigger takeout; in a more
 traditional app, this could be in settings.
 
-In order to start using it:
+**In order to start using it:**
 
 - [ ] Include the function and 4 supporting functions in `functions/index.js.`
 - [ ] In `user_privacy.json`, add:
@@ -91,7 +92,7 @@ access, another cannot restrict it.
 
 ### How to contribute to this repo
 
-- [ ] Clone this repository
+- [ ] Fork and clone this repository
 - [ ] Create a new firebase project and go through the `firebase init` flow.
 This project uses Hosting, Functions, the RealTime Database, Firestore, and
 Storage.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,53 @@ and copying out data at when a user requests it (the [`takeout` function]()).
 The functions are  flexible and easy to change to fit the needs of your specific
 users and apps.
 
-### How to play with these functions
+### How to contribute
 
 - [ ] Clone this repository
-- [ ] Create a new firebase project and go through the `firebase init` flow.
-This project uses Hosting, Functions, the RealTime Database, Firestore, and
-Storage.
+- [ ] Create a new firebase project and go through the `firebase init` flow. This project uses Hosting, Functions, the RealTime Database, Firestore, and Storage.
 - [ ] `cd` into the `functions` directory and `npm install`
 - [ ] Run `firebase deploy`
+
+
+### How to use these functions in your own project
+
+The `index.js` file has comments about how the functions work; this is about
+how to wire it up.
+
+The developer specifies the paths to data to wipeout or takeout. Those paths live in `user_privacy.json`. The data structures vary for each of the products:
+- For the RTDB, it’s a list of Strings to the path in the database of the form `"</users/uid/follows/..."`
+- For Firestore, it’s a list of Objects of the form `{ "collection": "admins",
+"doc": "UID_VARIABLE", "field": "email" }`.
+- For Storage, it’s a list of Lists with two elements, a bucket name and file name of the form `["cool-project.appspot.com", "users/uid/avatar.jpg"]`
+
+#### Wipeout function
+The wipeout function as written is triggered when a user deletes their account
+using firebase auth, and it performs a wipeout from all three services.
+
+Steps to start using wipeout:
+- [ ] Include the wipeout function and 3 supporting functions (and the requires and convenience variables) in `functions/index.js`
+- [ ] In `user_privacy.json`, add paths to personal information for all the products you’re using.
+- [ ] Make sure you’ve added the ability for the user to delete their account, because that’s what triggers the function
+- [ ] If you’re not using all three products, RTDB, Firestore, and Storage, remove the parts of the function that you don’t need.
+
+As an FYI, the wipeout is implemented by collecting a promise for every deletion event that needs to occur. Only when all promises resolve is the wipeout considered complete. Keep that in mind if you send a confirmation message that wipeout has completed.
+
+#### Takeout function
+The takeout function is triggered via a HTTP request. (The sample app in
+  `/public` has a button that’s wired up to trigger takeout, but in a more
+  traditional app, that would be in settings.)
+
+In order to start using it:
+
+- [ ] Include the function and 4 supporting functions in `functions/index.js.`
+- [ ] In `user_privacy.json`, add:
+  - [ ] A ``"takeoutUploadBucket"`` key that maps to the name of your primary bucket (or in the case of the free tier, your only bucket).
+  - [ ] Paths to personal information for all the products you’re using.
+- [ ] Wire it up in a way appropriate for your platform. For web, I added a
+button in `public/index.html`, that triggers a POST request, and add a rewrite entry in `firebase.json` to trigger the function via HTTP.
+- [ ] If you’re not using all three products, RTDB, Firestore, and Storage,
+remove the parts of the function you don’t need.
+
+Takeout for Storage is weird because we copy the data to a folder for that user, and also create the json of references.
+
+The storage.rules additions are extremely important for takeout. Without them, all the takeout data is freely available. We next the final takeout output under `/takeout`, but check to make sure you don’t have have wildcards in your storage rules, that will also apply to the takeout section.


### PR DESCRIPTION
I omitted usage instructions from the README; that was my mistake. This PR adds instructions to include the wipeout and takeout functions in a new project.

Because the functions cover wipeout and takeout for the Realtime Database, Firestore, and Storage, this also includes instructions for deleting the functions you don't need, though there's no harm in leaving them in.

💡 